### PR TITLE
add tests for case return node matching reference vs return new node on matched reference

### DIFF
--- a/fasthttp_test.go
+++ b/fasthttp_test.go
@@ -379,6 +379,53 @@ func TestFastHTTPPanicMiddleware(t *testing.T) {
 	}
 }
 
+func TestFastHTTPNodeApplyMiddlewareOne(t *testing.T) {
+	t.Parallel()
+
+	router := NewFastHTTPRouter().(*fastHTTPRouter)
+
+	router.GET("/x/{param}", func(ctx *fasthttp.RequestCtx) {
+		params := ctx.UserValue("params").(context.Params)
+		if _, err := fmt.Fprintf(ctx, "%s", params.Value("param")); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m1"))
+
+	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/y")
+
+	router.HandleFastHTTP(ctx)
+
+	if string(ctx.Response.Body()) != "y" {
+		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
+	}
+}
+
+func TestFastHTTPNodeApplyMiddlewareTwo(t *testing.T) {
+	t.Parallel()
+
+	router := NewFastHTTPRouter().(*fastHTTPRouter)
+
+	router.GET("/x/{param}", func(ctx *fasthttp.RequestCtx) {
+		params := ctx.UserValue("params").(context.Params)
+		if _, err := fmt.Fprintf(ctx, "%s", params.Value("param")); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	router.USE(http.MethodGet, "/x/{param}", mockFastHTTPMiddleware("m1"))
+	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m2"))
+
+	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/y")
+
+	router.HandleFastHTTP(ctx)
+
+	if string(ctx.Response.Body()) != "m1y" {
+		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
+	}
+}
+
 func TestFastHTTPNodeApplyMiddleware(t *testing.T) {
 	t.Parallel()
 

--- a/fasthttp_test.go
+++ b/fasthttp_test.go
@@ -379,7 +379,7 @@ func TestFastHTTPPanicMiddleware(t *testing.T) {
 	}
 }
 
-func TestFastHTTPNodeApplyMiddlewareOne(t *testing.T) {
+func TestFastHTTPNodeApplyMiddleware(t *testing.T) {
 	t.Parallel()
 
 	router := NewFastHTTPRouter().(*fastHTTPRouter)
@@ -400,24 +400,11 @@ func TestFastHTTPNodeApplyMiddlewareOne(t *testing.T) {
 	if string(ctx.Response.Body()) != "y" {
 		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
 	}
-}
-
-func TestFastHTTPNodeApplyMiddleware(t *testing.T) {
-	t.Parallel()
-
-	router := NewFastHTTPRouter().(*fastHTTPRouter)
-
-	router.GET("/x/{param}", func(ctx *fasthttp.RequestCtx) {
-		params := ctx.UserValue("params").(context.Params)
-		if _, err := fmt.Fprintf(ctx, "%s", params.Value("param")); err != nil {
-			t.Fatal(err)
-		}
-	})
 
 	router.USE(http.MethodGet, "/x/{param}", mockFastHTTPMiddleware("m1"))
 	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m2"))
 
-	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/y")
+	ctx = buildFastHTTPRequestContext(http.MethodGet, "/x/y")
 
 	router.HandleFastHTTP(ctx)
 

--- a/fasthttp_test.go
+++ b/fasthttp_test.go
@@ -402,30 +402,6 @@ func TestFastHTTPNodeApplyMiddlewareOne(t *testing.T) {
 	}
 }
 
-func TestFastHTTPNodeApplyMiddlewareTwo(t *testing.T) {
-	t.Parallel()
-
-	router := NewFastHTTPRouter().(*fastHTTPRouter)
-
-	router.GET("/x/{param}", func(ctx *fasthttp.RequestCtx) {
-		params := ctx.UserValue("params").(context.Params)
-		if _, err := fmt.Fprintf(ctx, "%s", params.Value("param")); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	router.USE(http.MethodGet, "/x/{param}", mockFastHTTPMiddleware("m1"))
-	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m2"))
-
-	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/y")
-
-	router.HandleFastHTTP(ctx)
-
-	if string(ctx.Response.Body()) != "m1y" {
-		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
-	}
-}
-
 func TestFastHTTPNodeApplyMiddleware(t *testing.T) {
 	t.Parallel()
 
@@ -439,22 +415,13 @@ func TestFastHTTPNodeApplyMiddleware(t *testing.T) {
 	})
 
 	router.USE(http.MethodGet, "/x/{param}", mockFastHTTPMiddleware("m1"))
+	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m2"))
 
 	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/y")
 
 	router.HandleFastHTTP(ctx)
 
 	if string(ctx.Response.Body()) != "m1y" {
-		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
-	}
-
-	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m2"))
-
-	ctx = buildFastHTTPRequestContext(http.MethodGet, "/x/x")
-
-	router.HandleFastHTTP(ctx)
-
-	if string(ctx.Response.Body()) != "m1m2x" {
 		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
 	}
 }

--- a/mux/tree.go
+++ b/mux/tree.go
@@ -137,11 +137,15 @@ func (t Tree) WithMiddleware(path string, m middleware.Middleware) Tree {
 
 	// try to find node by matching name against nodes
 	if node == nil {
-		node, _, _, _ = t.Match(name)
-	}
+		if node, _, _, _ = t.Match(name); node == nil {
+			panic("Could not find node for given path")
+		} else {
+			newNode := NewNode(parts[0], 0)
+			newNode.WithRoute(node.Route())
+			newTree = t.withNode(newNode)
 
-	if node == nil {
-		panic("Could not find node for given path")
+			return newTree
+		}
 	}
 
 	if len(parts) == 1 {

--- a/mux/tree.go
+++ b/mux/tree.go
@@ -142,6 +142,7 @@ func (t Tree) WithMiddleware(path string, m middleware.Middleware) Tree {
 		} else {
 			newNode := NewNode(parts[0], 0)
 			newNode.WithRoute(node.Route())
+			newNode.AppendMiddleware(m)
 			newTree = t.withNode(newNode)
 
 			return newTree

--- a/nethttp_test.go
+++ b/nethttp_test.go
@@ -401,7 +401,7 @@ func TestPanicMiddleware(t *testing.T) {
 	}
 }
 
-func TestNodeApplyMiddlewareOne(t *testing.T) {
+func TestNodeApplyMiddleware(t *testing.T) {
 	t.Parallel()
 
 	router := New().(*router)
@@ -430,29 +430,12 @@ func TestNodeApplyMiddlewareOne(t *testing.T) {
 	if w.Body.String() != "y" {
 		t.Errorf("Use middleware error %s", w.Body.String())
 	}
-}
-
-func TestNodeApplyMiddleware(t *testing.T) {
-	t.Parallel()
-
-	router := New().(*router)
-
-	router.GET("/x/{param}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		params, ok := context.Parameters(r.Context())
-		if !ok {
-			t.Fatal("Error while reading param")
-		}
-
-		if _, err := w.Write([]byte(params.Value("param"))); err != nil {
-			t.Fatal(err)
-		}
-	}))
 
 	router.USE(http.MethodGet, "/x/{param}", mockMiddleware("m1"))
 	router.USE(http.MethodGet, "/x/x", mockMiddleware("m2"))
 
-	w := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/x/y", nil)
+	w = httptest.NewRecorder()
+	req, err = http.NewRequest(http.MethodGet, "/x/y", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
add tests demonstrating the issue when returning matched node reference instead of returning new node on matched reference