### PR TITLE
Reverse order of middleware slice when adding orphan node.

### DIFF
--- a/fasthttp_test.go
+++ b/fasthttp_test.go
@@ -392,21 +392,23 @@ func TestFastHTTPNodeApplyMiddleware(t *testing.T) {
 	})
 
 	router.USE(http.MethodGet, "/x/{param}", mockFastHTTPMiddleware("m1"))
-	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m2"))
+	router.USE(http.MethodGet, "/x/y", mockFastHTTPMiddleware("m2"))
 
 	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/y")
 
 	router.HandleFastHTTP(ctx)
 
-	if string(ctx.Response.Body()) != "m1y" {
+	if string(ctx.Response.Body()) != "m1m2y" {
 		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
 	}
+
+	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m3"))
 
 	ctx = buildFastHTTPRequestContext(http.MethodGet, "/x/x")
 
 	router.HandleFastHTTP(ctx)
 
-	if string(ctx.Response.Body()) != "m2m1x" {
+	if string(ctx.Response.Body()) != "m1m3x" {
 		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
 	}
 }

--- a/fasthttp_test.go
+++ b/fasthttp_test.go
@@ -435,6 +435,30 @@ func TestFastHTTPNodeApplyMiddlewareStatic(t *testing.T) {
 	}
 }
 
+func TestFastHTTPNodeApplyMiddlewareDeepStatic(t *testing.T) {
+	t.Parallel()
+
+	router := NewFastHTTPRouter().(*fastHTTPRouter)
+
+	router.GET("/x/x/{param}", func(ctx *fasthttp.RequestCtx) {
+		if _, err := fmt.Fprintf(ctx, "x"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	router.USE(http.MethodGet, "/x/x", mockFastHTTPMiddleware("m1"))
+	router.USE(http.MethodGet, "/x/x/{param}", mockFastHTTPMiddleware("m2"))
+	router.USE(http.MethodGet, "/x/x/x", mockFastHTTPMiddleware("m3"))
+
+	ctx := buildFastHTTPRequestContext(http.MethodGet, "/x/x/x")
+
+	router.HandleFastHTTP(ctx)
+
+	if string(ctx.Response.Body()) != "m1m2m3x" {
+		t.Errorf("Use middleware error %s", string(ctx.Response.Body()))
+	}
+}
+
 func TestFastHTTPNodeApplyMiddlewareInvalidNodeReference(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -39,7 +39,7 @@ func (m Middleware) Compose(h interface{}) interface{} {
 
 // Reverse reverses middleware order. Needed after adding orphan nodes
 func (m Middleware) Reverse() Middleware {
-	n := reflect.ValueOf(m).Len()
+	n := len(m)
 	swap := reflect.Swapper(m)
 	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
 		swap(i, j)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,5 +1,7 @@
 package middleware
 
+import "reflect"
+
 // MiddlewareFunc is a middleware function type.
 // Long story - short: it is a handler wrapper
 type MiddlewareFunc func(interface{}) interface{}
@@ -33,4 +35,15 @@ func (m Middleware) Compose(h interface{}) interface{} {
 	}
 
 	return h
+}
+
+// helper function needed to reverse order when adding orphan nodes
+func (m Middleware) ReverseAny() Middleware {
+	n := reflect.ValueOf(m).Len()
+	swap := reflect.Swapper(m)
+	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
+		swap(i, j)
+	}
+
+	return m
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -37,8 +37,8 @@ func (m Middleware) Compose(h interface{}) interface{} {
 	return h
 }
 
-// helper function needed to reverse order when adding orphan nodes
-func (m Middleware) ReverseAny() Middleware {
+// Reverse reverses middleware order. Needed after adding orphan nodes
+func (m Middleware) Reverse() Middleware {
 	n := reflect.ValueOf(m).Len()
 	swap := reflect.Swapper(m)
 	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -99,3 +99,30 @@ func TestCompose(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestReverse(t *testing.T) {
+	m1 := mockMiddleware("1")
+	m2 := mockMiddleware("2")
+	m3 := mockMiddleware("3")
+
+	fn := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("4"))
+	})
+
+	m := New(m1)
+	m = m.Merge(New(m2, m3))
+	m.ReverseAny()
+	h := m.Compose(fn).(http.Handler)
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h.ServeHTTP(w, r)
+
+	if w.Body.String() != "3214" {
+		t.Errorf("The order is incorrect expected: 3214 actual: %s", w.Body.String())
+	}
+}

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -111,7 +111,7 @@ func TestReverse(t *testing.T) {
 
 	m := New(m1)
 	m = m.Merge(New(m2, m3))
-	m.ReverseAny()
+	m.Reverse()
 	h := m.Compose(fn).(http.Handler)
 
 	w := httptest.NewRecorder()

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -106,7 +106,10 @@ func TestReverse(t *testing.T) {
 	m3 := mockMiddleware("3")
 
 	fn := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("4"))
+		_, err := w.Write([]byte("4"))
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	m := New(m1)

--- a/mux/tree.go
+++ b/mux/tree.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -77,6 +78,14 @@ func (t Tree) Compile() Tree {
 	return t
 }
 
+func reverseAny(s interface{}) {
+	n := reflect.ValueOf(s).Len()
+	swap := reflect.Swapper(s)
+	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
+		swap(i, j)
+	}
+}
+
 // Match path to Node
 func (t Tree) Match(path string) (Node, middleware.Middleware, context.Params, string) {
 	var orphanMatches []match
@@ -87,6 +96,7 @@ func (t Tree) Match(path string) (Node, middleware.Middleware, context.Params, s
 				if len(orphanMatches) > 0 {
 					for i := 0; i < len(orphanMatches); i++ {
 						m = orphanMatches[i].node.Middleware().Merge(m)
+						reverseAny(m)
 					}
 				}
 

--- a/mux/tree.go
+++ b/mux/tree.go
@@ -87,7 +87,7 @@ func (t Tree) Match(path string) (Node, middleware.Middleware, context.Params, s
 				if len(orphanMatches) > 0 {
 					for i := 0; i < len(orphanMatches); i++ {
 						m = orphanMatches[i].node.Middleware().Merge(m)
-						m.ReverseAny()
+						m.Reverse()
 					}
 				}
 

--- a/mux/tree.go
+++ b/mux/tree.go
@@ -3,7 +3,6 @@ package mux
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -78,14 +77,6 @@ func (t Tree) Compile() Tree {
 	return t
 }
 
-func reverseAny(s interface{}) {
-	n := reflect.ValueOf(s).Len()
-	swap := reflect.Swapper(s)
-	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
-		swap(i, j)
-	}
-}
-
 // Match path to Node
 func (t Tree) Match(path string) (Node, middleware.Middleware, context.Params, string) {
 	var orphanMatches []match
@@ -96,7 +87,7 @@ func (t Tree) Match(path string) (Node, middleware.Middleware, context.Params, s
 				if len(orphanMatches) > 0 {
 					for i := 0; i < len(orphanMatches); i++ {
 						m = orphanMatches[i].node.Middleware().Merge(m)
-						reverseAny(m)
+						m.ReverseAny()
 					}
 				}
 

--- a/mux/tree.go
+++ b/mux/tree.go
@@ -87,7 +87,7 @@ func (t Tree) Match(path string) (Node, middleware.Middleware, context.Params, s
 				if len(orphanMatches) > 0 {
 					for i := 0; i < len(orphanMatches); i++ {
 						m = orphanMatches[i].node.Middleware().Merge(m)
-						m.Reverse()
+						//m.Reverse()
 					}
 				}
 

--- a/nethttp_test.go
+++ b/nethttp_test.go
@@ -501,6 +501,35 @@ func TestNodeApplyMiddlewareDeepStatic(t *testing.T) {
 	}
 }
 
+func TestNodeApplyMiddlewareWidlcardStaticMix(t *testing.T) {
+	t.Parallel()
+
+	router := New().(*router)
+
+	router.GET("/x/{param}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte("handler")); err != nil {
+			t.Fatal(err)
+		}
+	}))
+
+	router.USE(http.MethodGet, "/", mockMiddleware("m1->"), mockMiddleware("m2->"))
+	router.USE(http.MethodGet, "/x", mockMiddleware("mx1->"), mockMiddleware("mx2->"))
+	router.USE(http.MethodGet, "/x/{param}", mockMiddleware("mparam1->"), mockMiddleware("mparam2->"))
+	router.USE(http.MethodGet, "/x/y", mockMiddleware("mxy1->"), mockMiddleware("mxy2->"))
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/x/y", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router.ServeHTTP(w, req)
+
+	if w.Body.String() != "m1->m2->mx1->mx2->mxy1->mxy2->mparam1->mparam2->handler" {
+		t.Errorf("Use middleware error %s", w.Body.String())
+	}
+}
+
 func TestNodeApplyMiddlewareInvalidNodeReference(t *testing.T) {
 	t.Parallel()
 

--- a/nethttp_test.go
+++ b/nethttp_test.go
@@ -418,7 +418,7 @@ func TestNodeApplyMiddleware(t *testing.T) {
 	}))
 
 	router.USE(http.MethodGet, "/x/{param}", mockMiddleware("m1"))
-	router.USE(http.MethodGet, "/x/x", mockMiddleware("m2"))
+	router.USE(http.MethodGet, "/x/y", mockMiddleware("m2"))
 
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, "/x/y", nil)
@@ -428,9 +428,11 @@ func TestNodeApplyMiddleware(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	if w.Body.String() != "m1y" {
+	if w.Body.String() != "m1m2y" {
 		t.Errorf("Use middleware error %s", w.Body.String())
 	}
+
+	router.USE(http.MethodGet, "/x/x", mockMiddleware("m3"))
 
 	w = httptest.NewRecorder()
 	req, err = http.NewRequest(http.MethodGet, "/x/x", nil)
@@ -440,7 +442,7 @@ func TestNodeApplyMiddleware(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	if w.Body.String() != "m2m1x" {
+	if w.Body.String() != "m1m3x" {
 		t.Errorf("Use middleware error %s", w.Body.String())
 	}
 }


### PR DESCRIPTION
Add notes to docs that middleware is defined descending broader to specific and wildcard to static.